### PR TITLE
Remove debug logs from notes editor

### DIFF
--- a/web/components/note-editor.tsx
+++ b/web/components/note-editor.tsx
@@ -21,8 +21,7 @@ interface NoteEditorProps {
 }
 
 export function NoteEditor({ content, onChange, className, onEditorReady }: NoteEditorProps) {
-  // Add debugging to check the received content
-  console.log("NoteEditor received content:", content);  const editor = useEditor({
+  const editor = useEditor({
     extensions: [
       StarterKit.configure({
         hardBreak: {
@@ -54,12 +53,13 @@ export function NoteEditor({ content, onChange, className, onEditorReady }: Note
         allowBase64: true,
         inline: true,
       }),
-    ],    content,    onUpdate: ({ editor }) => {
-      // Get the full HTML content and log it for debugging
+    ],
+    content,
+    onUpdate: ({ editor }) => {
       const html = editor.getHTML();
-      console.log("Editor updated, HTML content:", html);
       onChange(html);
-    },    editorProps: {
+    },
+    editorProps: {
       attributes: {
         class: 'focus:outline-none prose prose-sm sm:prose max-w-none p-4 h-full min-h-[200px] overflow-auto',
       },
@@ -71,11 +71,11 @@ export function NoteEditor({ content, onChange, className, onEditorReady }: Note
     if (editor && onEditorReady) {
       onEditorReady(editor);
     }
-  }, [editor, onEditorReady]);  // Update editor content when content prop changes
+  }, [editor, onEditorReady]);
+
+  // Update editor content when content prop changes
   useEffect(() => {
     if (editor && content !== editor.getHTML()) {
-      console.log("Updating editor content:", content);
-      // Ensure proper HTML parsing by using setContent with specific options
       editor.commands.setContent(content, false);
     }
   }, [content, editor]);

--- a/web/components/note-viewer.tsx
+++ b/web/components/note-viewer.tsx
@@ -9,8 +9,7 @@ interface NoteViewerProps {
 }
 
 export function NoteViewer({ content, className }: NoteViewerProps) {
-  // Add debugging to check the received content
-  console.log("NoteViewer received content:", content);  return (
+  return (
     <div 
       className={cn(
         "note-viewer prose prose-sm sm:prose max-w-none p-4 rounded-md bg-background overflow-auto whitespace-pre-wrap",


### PR DESCRIPTION
## Summary
- remove leftover debug logging from `NoteEditor` component
- drop debug output in `NoteViewer`

## Testing
- `npm install`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6870237d7ddc8321a54cf850d2f9b473